### PR TITLE
Fixed search and layout issues

### DIFF
--- a/css/component.css
+++ b/css/component.css
@@ -117,3 +117,18 @@
 .no-js .sb-search .sb-search-submit {
 	z-index: 90;
 }
+
+/* I changed the width of the search bar expansion so it fits on the side of the nav*/
+@media (min-width: 768px) {
+	.sb-search.sb-search-open,
+	.no-js .sb-search {
+		width: 40%;
+	}
+}
+
+@media (min-width: 992px) {
+	.sb-search.sb-search-open,
+	.no-js .sb-search {
+		width: 25%;
+	}
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -49,7 +49,7 @@ h4 {
 h5 {
     font-family: gotham-bold, arial;
     font-size: 1.5em;
-    text-transform: uppercase; 
+    text-transform: uppercase;
     line-height: 1em;}
 
 
@@ -180,7 +180,7 @@ nav {
     text-transform: uppercase;
     text-shadow: none;
     box-shadow: none;
-    border: none; 
+    border: none;
     border-radius: none;
     background-image: none;
     margin-bottom: 2em;}
@@ -285,7 +285,7 @@ figure img {
 
 .recipe span {
     color: #ea6045;
-    margin-right: 1em;}  
+    margin-right: 1em;}
 
 
 .recipe-img {
@@ -376,8 +376,8 @@ footer h6 {
 
 
 @media screen and (min-width: 768px) {
-    
-    
+
+
  /* ==================================
     SM HEADER
 ===================================== */
@@ -397,16 +397,16 @@ header h2 {
 
 .header-text {
     margin-top: 20%;
-    text-align: center;}  
-    
-    
-    
-    
-    
-    
-    
-    
-    
+    text-align: center;}
+
+
+
+
+
+
+
+
+
 /* ==================================
     SM NAV
 ===================================== */
@@ -427,28 +427,28 @@ nav {
 .nav-justified li a {
     text-align: center;
     background-color: #FFFFFF;}
-    
-    
+
+
 .nav-justified {
     background-color: #FFFFFF;
     padding-top: .6em;
-    width: 90%;}
-    
+    width: 60%;} /* changed to 60% so the search bar can fit on the side when on tablet*/
+
 
 .navbar-collapse a:hover {
     color: #ea6045;
     background-color: #FFFFFF;}
-    
-    
 
-    
-    
-    
-    
-    
-    
-    
-    
+
+
+
+
+
+
+
+
+
+
 
 /* ==================================
     SM SUB-NAV
@@ -459,7 +459,7 @@ nav {
     text-transform: uppercase;
     text-shadow: none;
     box-shadow: none;
-    border: none; 
+    border: none;
     border-radius: none;
     background-image: none;
     margin-top: 2em;}
@@ -468,14 +468,14 @@ nav {
 .btn-group-justified strong {
     color: #ea6045;}
 
-    
-    
-    
-    
-    
-    
-    
-    
+
+
+
+
+
+
+
+
 /* ==================================
     SM FIGS
 ===================================== */
@@ -517,14 +517,14 @@ figure {
 figure img {
     height: auto;
     max-width: 100%;}
-    
-    
-    
-    
-    
-    
-    
-    
+
+
+
+
+
+
+
+
 /* ==================================
     SM RECIPE PAGE
 ===================================== */
@@ -540,7 +540,7 @@ figure img {
 
 .recipe span {
     color: #ea6045;
-    margin-right: .2em;}  
+    margin-right: .2em;}
 
 
 .recipe-img {
@@ -583,18 +583,18 @@ article strong {
     margin-right: 1em;
     margin-top: 3em;
     margin-bottom: 5em;}
-    
-    
+
+
 .prep {
     margin-top: 5em;
     margin-left: 2em;}
-    
-    
-    
-    
-    
-    
-    
+
+
+
+
+
+
+
 
 /* ==================================
     SM FOOTER
@@ -613,16 +613,18 @@ footer {
 footer h6 {
     text-align: center;
     font-size: 1.2em;}
-    
-    
-    
-    
-    
-    
-    
-    
-}   
-    
-    
-    
-    
+
+
+
+
+
+
+
+
+}
+
+@media (min-width: 992px) {
+  .nav-justified {
+      width: 74%;} /* changed to 74% so the search bar can fit on the side when on desktop*/
+
+}

--- a/index.html
+++ b/index.html
@@ -25,22 +25,22 @@
 <body>
 
 
-    
+
 <nav>
     <div class="navbar-header">
         <button type="button" class="navbar-toggle visible-xs" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
             <span class="sr-only">Toggle navigation</span>
             <span class="glyphicon glyphicon-menu-hamburger"></span>
         </button>
-        
-            
-    <ul class="collapse navbar-collapse  nav  nav-justified list-unstyled" id="bs-example-navbar-collapse-1">
+
+
+    <ul class="col-sm-8 collapse navbar-collapse  nav nav-justified list-unstyled" id="bs-example-navbar-collapse-1">
         <li><a href="index.html">Home</a></li>
         <li><a href="food.html">Food</a></li>
         <li><a href="#">Drinks</a></li>
         <li><a href="#">Videos</a></li>
     </ul>
-        
+
         <div id="sb-search" class="sb-search">
 						<form>
 							<input class="sb-search-input" placeholder="Enter your search term..." type="text" value="" name="search" id="search">
@@ -49,15 +49,15 @@
 						</form>
 					</div>
 
-    
+
         </div>
-</nav>  
-    
-    
-    
- 
-    
-    
+</nav>
+
+
+
+
+
+
 <header class="container-fluid">
     <div class="header-text">
     <div class="col-xs-8 col-xs-offset-2"><h1>savor</h1>
@@ -69,95 +69,101 @@
       </span>
     </div>
     </div>
-    
+
 </header>
-    
-    
-    
-    
-    
-<main class="container-fluid col-sm-10 col-sm-offset-2">   
-  
-    
-<a href="recipe.html" class="pull">  
+
+
+
+
+
+<main class="container-fluid col-sm-10 col-sm-offset-1"> <!--this should be offset by 1 since you want the same margin replicated on the right as well-->
+
+
+<a href="recipe.html" class="pull">
 <figure class="pull col-xs-12">
     <img src="images/ziti_xs.jpg" alt="Three-Cheese Baked Ziti" class="img-responsive visible-xs"/>
-     
+
 <img src="images/ziti_sm.jpg" alt="Three-Cheese Baked Ziti" class="img-responsive hidden-xs"/>
     <figcaption>
         <span class="label label-default">Pasta</span>
         <h5>Three-Cheese <br>Baked Ziti</h5>
     </figcaption>
 </figure></a>
-    
-     
-     
-     
-<figure class="row col-xs-12 col-sm-5 pull-left">
+
+
+
+
+<figure class="col-xs-12 col-sm-5 pull-left">
+  <div class="row">
     <img src="images/figure/bagel-sandwich.jpg" alt="bagel sandwich" class="img-responsive"/>
-    <figcaption>     
+    <figcaption>
         <h5>Recipe Title</h5>
         <span class="label label-default">Category</span>
     </figcaption>
+  </div>
 </figure>
-    
-    
-     
 
-    
-    
-     
-<figure class="row col-xs-12 col-sm-5 pull-left">
+
+
+
+
+<!-- You should have your row class on a child element or else it only knocks off the padding on the left side. See below-->
+
+<figure class="col-xs-12 col-sm-5 pull-left">
+  <div class="row"> <!--I moved the row to this div so the padding is removed from both sides-->
     <img src="images/figure/vegetable-salad.jpg" alt="vegetable salad" class="img-responsive"/>
-    <figcaption>     
+    <figcaption>
         <h5>Recipe Title</h5>
         <span class="label label-default">Category</span>
     </figcaption>
+  </div><!--closes row-->
 </figure>
-     
-    
-     
-<figure class="row col-xs-12 col-sm-5 pull-left">
-    <img src="images/figure/buschetta.jpg" alt="bruschetta" class="img-responsive"/>
-    <figcaption>     
-        <h5>Recipe Title</h5>
-        <span class="label label-default">Category</span>
-    </figcaption>
-</figure>
-     
-     
-     
-     
-     
-    
-    
-    
-    
-<footer class="row col-xs-12">
 
+
+
+<figure class="col-xs-12 col-sm-5 pull-left">
+  <div class="row">
+    <img src="images/figure/buschetta.jpg" alt="bruschetta" class="img-responsive"/>
+    <figcaption>
+        <h5>Recipe Title</h5>
+        <span class="label label-default">Category</span>
+    </figcaption>
+  </div>
+</figure>
+
+
+
+
+
+
+
+
+
+<footer class="col-xs-12">
+<div class="row">
     <h6>subscribe for new recipes</h6>
-    
+
     <div></div>
-     
-</footer>   
-    
-    
-    
-    
-    
-    
-    
-    
-    
+</div>
+</footer>
+
+
+
+
+
+
+
+
+
 
 
 </main>
-     
-     
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>   
-    
- <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script> 
-    
+
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+
+ <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+
 <script src="js/classie.js"></script>
 		<script src="js/uisearch.js"></script>
 		<script>


### PR DESCRIPTION
Your search bar was jumping down on tablet because there was no room
for it once the menu items in the nav were revealed. I had to shorten
the <ul>, and the expanded width of the search bar on tablet and
desktop, to make them both fit on the same line.

Your main content on tablet was being offset by 2 even though you had
it at 10 columns. In order to have even margins on both sides, you
needed to offset it by 1. Here is the logic: 1 column left + 10 column
width, and a remainder of 1 column left on the right side.
